### PR TITLE
Feature/apm prometheus grafana

### DIFF
--- a/authentication/base.py
+++ b/authentication/base.py
@@ -3,6 +3,7 @@ from flask_marshmallow import Marshmallow
 from flask_restful import Api
 from flask_sqlalchemy import SQLAlchemy
 from flask_jwt_extended import JWTManager
+from prometheus_flask_exporter import PrometheusMetrics
 
 app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] =  'postgresql+psycopg2://postgres:1234@database:5432/postgres'
@@ -14,6 +15,7 @@ app_context.push()
 db = SQLAlchemy(app)
 ma = Marshmallow(app)
 jwt = JWTManager(app)
+metrics = PrometheusMetrics(app)
 api = Api(app)
 
 class Usuario(db.Model):

--- a/authentication/requirements.txt
+++ b/authentication/requirements.txt
@@ -10,3 +10,4 @@ SQLAlchemy
 marshmallow-sqlalchemy
 psycopg2-binary
 flask-jwt-extended
+prometheus_flask_exporter

--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -6,6 +6,7 @@ FROM python:latest
 WORKDIR /app
 
 # Copy the Dockerfile file to the working directory
+COPY ./batch/celery.sh .
 COPY ./uploader/async_video_processor.py .
 COPY ./uploader/requirements.txt .
 COPY ./uploader/base.py .
@@ -13,5 +14,6 @@ COPY ./uploader/base.py .
 # Install the Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
+RUN ["chmod", "+x", "celery.sh"]
 # Run Celery with the "batch_video" queue
-ENTRYPOINT ["celery", "-A", "async_video_processor.celery", "worker", "-Q", "batch_videos", "-E", "-l", "info"]
+ENTRYPOINT ["/app/celery.sh"]

--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -13,7 +13,7 @@ COPY ./uploader/base.py .
 COPY ./uploader/celeryconfig.py .
 
 # Install the Python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install -r requirements.txt
 
 RUN ["chmod", "+x", "celery.sh"]
 # Run Celery with the "batch_video" queue

--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -10,6 +10,7 @@ COPY ./batch/celery.sh .
 COPY ./uploader/async_video_processor.py .
 COPY ./uploader/requirements.txt .
 COPY ./uploader/base.py .
+COPY ./uploader/celeryconfig.py .
 
 # Install the Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt

--- a/batch/celery.sh
+++ b/batch/celery.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+celery -A async_video_processor.celery worker -Q batch_videos -E -l info
+celery control enable_events

--- a/batch/celery.sh
+++ b/batch/celery.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
+celery -A async_video_processor.celery control enable_events
 celery -A async_video_processor.celery worker -Q batch_videos -E -l info
-celery control enable_events

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
   celery-exporter:
     image: danihodovic/celery-exporter
     environment:
-      CE_BROKER_URL: redis://broker:6379/1
+      CE_BROKER_URL: redis://broker:6379/0
     ports:
       - "9808:9808"
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,6 @@ services:
       - ./shared:/shared/
     depends_on:
       - broker
-      - uploader
     networks:
       network:
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,18 @@ services:
     networks:
       network:
 
+  celery-exporter:
+    image: danihodovic/celery-exporter
+    environment:
+      CE_BROKER_URL: redis://broker:6379/1
+    ports:
+      - "9808:9808"
+    depends_on:
+      - celery
+      - broker
+    networks:
+      network:
+
   broker:
     image: redis:latest
     ports:
@@ -30,6 +42,7 @@ services:
       - database
     networks:
       network:
+  
   authentication:
     build: ./authentication
     volumes:
@@ -40,6 +53,7 @@ services:
       - database
     networks:
       network:
+
   database:
     image: postgres
     restart: always
@@ -55,6 +69,19 @@ services:
       - PGDATA=/var/lib/postgresql/data/ifpvdl/
     networks:
       network:
+  
+  postgres-exporter:
+    image: prometheuscommunity/postgres-exporter
+    ports:
+      - 9187:9187
+    environment:
+      DATA_SOURCE_NAME: "postgresql://postgres:1234@database:5432/postgres?sslmode=disable"
+    links:
+      - database
+      - prometheus
+    networks:
+      network:
+
   nginx:
     image: nginx:latest
     ports:
@@ -69,5 +96,33 @@ services:
     networks:
       network:
 
+  prometheus:
+    image: prom/prometheus:v2.21.0
+    ports:
+      - 9000:9090
+    volumes:
+      - ./prometheus:/etc/prometheus
+      - prometheus-data:/prometheus
+    command: --web.enable-lifecycle  --config.file=/etc/prometheus/prometheus.yml
+    networks:
+      network:
+
+  grafana:
+    image: grafana/grafana:7.5.7
+    ports:
+      - 3000:3000
+    restart: unless-stopped
+    volumes:
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
+      - grafana-data:/var/lib/grafana
+    networks:
+      network:
+
+
 networks:
   network:
+
+  
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,18 +68,6 @@ services:
       - PGDATA=/var/lib/postgresql/data/ifpvdl/
     networks:
       network:
-  
-  postgres-exporter:
-    image: prometheuscommunity/postgres-exporter
-    ports:
-      - 9187:9187
-    environment:
-      DATA_SOURCE_NAME: "postgresql://postgres:1234@database:5432/postgres?sslmode=disable"
-    links:
-      - database
-      - prometheus
-    networks:
-      network:
 
   nginx:
     image: nginx:latest

--- a/grafana/provisioning/datasources/prometheus_ds.yml
+++ b/grafana/provisioning/datasources/prometheus_ds.yml
@@ -1,0 +1,6 @@
+datasources:
+- name: Prometheus
+  access: proxy
+  type: prometheus
+  url: http://prometheus:9090
+  isDefault: true

--- a/nginx/nginx-proxy.conf
+++ b/nginx/nginx-proxy.conf
@@ -4,6 +4,10 @@ server {
     ssl_certificate_key /etc/ssl/private/localhost.key;
     ssl_protocols TLSv1.2 TLSv1.1 TLSv1;
     client_max_body_size 100M;
+
+    location /metrics {
+        stub_status;
+    }
     
     location /api {
         proxy_pass https://uploader:5000;
@@ -21,6 +25,20 @@ server {
 
     location /api/users/login {
         proxy_pass https://authentication:5000;
+        proxy_set_header X-Real-IP  $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header Host $host;
+    }
+
+    location /auth/metrics {
+        proxy_pass https://authentication:5000/metrics;
+        proxy_set_header X-Real-IP  $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header Host $host;
+    }
+
+    location /uploader/metrics {
+        proxy_pass https://uploader:5000/metrics;
         proxy_set_header X-Real-IP  $remote_addr;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header Host $host;

--- a/nginx/nginx-proxy.conf
+++ b/nginx/nginx-proxy.conf
@@ -30,18 +30,4 @@ server {
         proxy_set_header Host $host;
     }
 
-    location /auth/metrics {
-        proxy_pass https://authentication:5000/metrics;
-        proxy_set_header X-Real-IP  $remote_addr;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_set_header Host $host;
-    }
-
-    location /uploader/metrics {
-        proxy_pass https://uploader:5000/metrics;
-        proxy_set_header X-Real-IP  $remote_addr;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_set_header Host $host;
-    }
-
 }

--- a/prometheus/alert.yml
+++ b/prometheus/alert.yml
@@ -1,0 +1,6 @@
+groups:
+  - name: DemoAlerts
+    rules:
+      - alert: InstanceDown 
+        expr: up{job="services"} < 1 
+        for: 5m 

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,23 @@
+global:
+  scrape_interval: 30s
+  scrape_timeout: 10s
+
+rule_files:
+  - alert.yml
+
+scrape_configs:
+  - job_name: other-services
+    static_configs:
+    
+      - targets:
+          - 'prometheus:9090'
+          - 'postgres-exporter:9187'
+          - 'celery-exporter:9808'
+  - job_name: flask-services
+    scheme: https
+    tls_config:
+      insecure_skip_verify: true
+    static_configs:
+      - targets:
+          - 'authentication:5000'
+          - 'uploader:5000'

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -11,7 +11,6 @@ scrape_configs:
     
       - targets:
           - 'prometheus:9090'
-          - 'postgres-exporter:9187'
           - 'celery-exporter:9808'
   - job_name: flask-services
     scheme: https

--- a/uploader/async_video_processor.py
+++ b/uploader/async_video_processor.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import celeryconfig
 
 from celery import Celery
 from celery.utils.log import get_task_logger
@@ -10,9 +11,8 @@ from base import Status, Video, db
 celery = Celery(
     "async_video_processor",
     broker='redis://broker:6379/0',
-    worker_send_task_events=True,
-    task_send_sent_event=True
 )
+celery.config_from_object(celeryconfig)
 logger = get_task_logger("async_video_processor")
 
 

--- a/uploader/async_video_processor.py
+++ b/uploader/async_video_processor.py
@@ -7,7 +7,12 @@ from moviepy.editor import VideoFileClip, concatenate_videoclips, ImageClip
 
 from base import Status, Video, db
 
-celery = Celery("async_video_processor", broker='redis://broker:6379/0')
+celery = Celery(
+    "async_video_processor",
+    broker='redis://broker:6379/0',
+    worker_send_task_events=True,
+    task_send_sent_event=True
+)
 logger = get_task_logger("async_video_processor")
 
 
@@ -65,7 +70,8 @@ def procesar_video(
              Video.processed_file_url: processed_file_name}
         )
         db.session.commit()
-        logger.info(f"Saved video in db: {processed_file_name} with id: {video_id}")
+        logger.info(
+            f"Saved video in db: {processed_file_name} with id: {video_id}")
     except Exception:
         db.session.query(Video).filter(Video.id == video_id).update(
             {Video.status: Status.incomplete, Video.processed_file_url: None}

--- a/uploader/async_video_processor.py
+++ b/uploader/async_video_processor.py
@@ -10,7 +10,6 @@ from base import Status, Video, db
 
 celery = Celery(
     "async_video_processor",
-    broker='redis://broker:6379/0',
 )
 celery.config_from_object(celeryconfig)
 logger = get_task_logger("async_video_processor")

--- a/uploader/base.py
+++ b/uploader/base.py
@@ -11,6 +11,7 @@ from flask_restful import Api
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import TIMESTAMP, Enum
 from flask_jwt_extended import JWTManager
+from prometheus_flask_exporter import PrometheusMetrics
 
 app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql+psycopg2://postgres:1234@database:5432/postgres'
@@ -38,9 +39,16 @@ app_context.push()
 db = SQLAlchemy(app)
 ma = Marshmallow(app)
 api = Api(app)
+metrics = PrometheusMetrics(app)
 jwt = JWTManager(app)
 
-celery_app = Celery("async_video_processor", broker='redis://broker:6379/0')
+celery_app = Celery(
+    "async_video_processor",
+    broker='redis://broker:6379/0',
+    worker_send_task_events=True,
+    task_send_sent_event=True
+)
+
 
 class Status(enum.Enum):
     incomplete = "incomplete"
@@ -69,4 +77,3 @@ class VideoSchema(ma.SQLAlchemyAutoSchema):
 
 video_schema = VideoSchema()
 videos_schema = VideoSchema(many=True)
-

--- a/uploader/base.py
+++ b/uploader/base.py
@@ -45,7 +45,6 @@ jwt = JWTManager(app)
 
 celery_app = Celery(
     "async_video_processor",
-    broker='redis://broker:6379/0'
 )
 celery_app.config_from_object(celeryconfig)
 

--- a/uploader/base.py
+++ b/uploader/base.py
@@ -2,6 +2,7 @@
 import datetime
 import enum
 import os
+import celeryconfig
 
 from celery import Celery
 from flask import Flask
@@ -44,11 +45,9 @@ jwt = JWTManager(app)
 
 celery_app = Celery(
     "async_video_processor",
-    broker='redis://broker:6379/0',
-    worker_send_task_events=True,
-    task_send_sent_event=True
+    broker='redis://broker:6379/0'
 )
-
+celery_app.config_from_object(celeryconfig)
 
 class Status(enum.Enum):
     incomplete = "incomplete"

--- a/uploader/celeryconfig.py
+++ b/uploader/celeryconfig.py
@@ -1,0 +1,2 @@
+worker_send_task_events = True
+task_send_sent_event = True

--- a/uploader/celeryconfig.py
+++ b/uploader/celeryconfig.py
@@ -1,2 +1,3 @@
 worker_send_task_events = True
 task_send_sent_event = True
+broker_url = 'redis://broker:6379/0'

--- a/uploader/requirements.txt
+++ b/uploader/requirements.txt
@@ -13,3 +13,4 @@ psycopg2-binary
 flask-jwt-extended
 celery
 celery[redis]
+prometheus_flask_exporter


### PR DESCRIPTION
Tenemos scrapers para cada uno de los componentes que considero importantes:

- celery
- postgres
- api
- authenticator

Prometheus es una herramienta que se encarga leer métricas de cada servicio. Por lo tanto, cada servicio debe proveer las métricas en un endpoint llamado /metrics, que puede ser privado en el caso del docker-compose. 

![image](https://github.com/MISW4204-2024-desarrollo-sw-nube/interna-FPV-drone-racing-league/assets/31115265/2000fff6-916c-4ec2-a9b5-827e671ae005)

Grafana es una herramienta que permite visualizar métricas de prometheus de manera fácil mediante la creación de gráficas.

![image](https://github.com/MISW4204-2024-desarrollo-sw-nube/interna-FPV-drone-racing-league/assets/31115265/bc83e4b6-675f-440f-91b7-ea7a53fd8f76)


La idea es correr prometheus, los scrapers de métricas de prometheus y grafana en la misma máquina virtual y armar las gráficas una vez todo esté montado.