### PR TITLE
feature: script for template

### DIFF
--- a/init_container.sh
+++ b/init_container.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Obtenido de https://tomroth.dev/gcp-docker/
-INSTANCE=$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/instance -H "Metadata-Flavor: Google")
+SERVICE=$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/instance -H "Metadata-Flavor: Google")
 
-echo $INSTANCE
+echo $SERVICE
 
 sudo apt update 
 sudo apt install --yes apt-transport-https ca-certificates curl gnupg2 software-properties-common
@@ -18,4 +18,4 @@ git clone https://github.com/MISW4204-2024-desarrollo-sw-nube/interna-FPV-drone-
 
 cd interna-FPV-drone-racing-league
 
-docker compose up $INSTANCE
+docker compose up $SERVICE

--- a/init_container.sh
+++ b/init_container.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # Obtenido de https://tomroth.dev/gcp-docker/
+INSTANCE=$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/instance -H "Metadata-Flavor: Google")
+
+echo $INSTANCE
+
 sudo apt update 
 sudo apt install --yes apt-transport-https ca-certificates curl gnupg2 software-properties-common
 curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
@@ -11,3 +15,7 @@ sudo apt-get install git
 
 # Clonando el repo
 git clone https://github.com/MISW4204-2024-desarrollo-sw-nube/interna-FPV-drone-racing-league.git
+
+cd interna-FPV-drone-racing-league
+
+docker compose up $INSTANCE

--- a/init_container.sh
+++ b/init_container.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Obtenido de https://tomroth.dev/gcp-docker/
+sudo apt update 
+sudo apt install --yes apt-transport-https ca-certificates curl gnupg2 software-properties-common
+curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+sudo apt update
+sudo apt install --yes docker-ce
+sudo apt-get install docker-compose-plugin
+sudo apt-get install git
+
+# Clonando el repo
+git clone https://github.com/MISW4204-2024-desarrollo-sw-nube/interna-FPV-drone-racing-league.git


### PR DESCRIPTION
Agregado el script que usa la máquina de templates. Hay cosas que ajustar de red para el balanceador y demás, pero se pueden generar máquinas que corran un servicio del docker-compose.


El instance template es el que se ve acá:

![image](https://github.com/MISW4204-2024-desarrollo-sw-nube/interna-FPV-drone-racing-league/assets/31115265/1272e420-101b-444c-8d40-2b22873c2d5f)

Ejemplo de configuración para que corra el uploader (toca ponerle la metadata instance y el nombre del servicio (o servicios) que se quieren correr)

![image](https://github.com/MISW4204-2024-desarrollo-sw-nube/interna-FPV-drone-racing-league/assets/31115265/4d118205-4e91-43b3-8ec1-cd840921d044)

Ejemplo de los logs de la máquina funcionando (creó el uploader)

![image](https://github.com/MISW4204-2024-desarrollo-sw-nube/interna-FPV-drone-racing-league/assets/31115265/10667483-3478-429d-8f73-b420d180d8a2)


