### PR TITLE
Remove NFS functionality from uploader and worker

### DIFF
--- a/uploader/api_commands.py
+++ b/uploader/api_commands.py
@@ -71,7 +71,9 @@ def upload_video():
 
     # Upload to GCS bucket
     try:
-        destination_blob_name = f"{unproccessedVideosName}/{filename_with_timestamp}"
+        destination_blob_name = (
+            f"{unproccessedVideosName}/{user_id}/{filename_with_timestamp}"
+        )
 
         storage_client = storage.Client()
         bucket = storage_client.bucket(cloud_storage_bucket)

--- a/uploader/async_video_processor.py
+++ b/uploader/async_video_processor.py
@@ -25,6 +25,7 @@ def procesar_video(
     cloud_storage_bucket,
     proccessedVideosName,
     unproccessedVideosName,
+    user_id,
 ):
     unprocessed_file_path = os.path.join(
         current_unprocessed_folder, unprocessed_file_name
@@ -36,7 +37,9 @@ def procesar_video(
         storage_client = storage.Client()
         bucket = storage_client.bucket(cloud_storage_bucket)
 
-        unprocessed_blob_name = f"{unproccessedVideosName}/{unprocessed_file_name}"
+        unprocessed_blob_name = (
+            f"{unproccessedVideosName}/{user_id}/{unprocessed_file_name}"
+        )
         blob = bucket.blob(unprocessed_blob_name)
         blob.download_to_filename(unprocessed_file_path)
         logger.info("Downloaded video")
@@ -77,7 +80,9 @@ def procesar_video(
         logger.info(f"Processed video: {processed_file_path}")
 
         # Upload to GCS bucket
-        destination_blob_name = f"{proccessedVideosName}/{processed_file_name}"
+        destination_blob_name = (
+            f"{proccessedVideosName}/{user_id}/{processed_file_name}"
+        )
         blob = bucket.blob(destination_blob_name)
         with open(processed_file_path, "rb") as file:
             logger.info("Started uploading video...")


### PR DESCRIPTION
Este PR remueve la funcionalidad de NFS de la aplicación. Especificamente, el guardado y recuperación de archivos desde el sistema de archivos local con el objetivo de sincronizarlos.

Se sigue usando el sistema de arvhivos local en el worker de celery debido a que la librería moviepy lo requiere para la manipulación de los videos.

Items:
- Ya no se crean las carpetas ni se guardan los archivos en el uploader
- Se sube el archivo a Google Cloud Storage desde el uploader
- En el worker, lo primero que se hace es descargar el archivo desde Google Cloud Storage
- Luego de procesar el video, el worker sube el nuevo video a Cloud Storage
- Finalmente el worker elimina los archivos del sistema local
- Finalmente en el api del uploader, en el endpoint para borrar un video, ya no se elimina del sistema local sino de Cloud Storage